### PR TITLE
Update versioning from repo / build process

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,8 @@
 [flake8]
 select = B,B9,BLK,C,D,DAR,E,F,I,S,W
 
+exclude = ceresfit/_version.py
+
 # black configuration
 ignore = E203,E501,W503
 max-line-length = 88

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,10 +21,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flit
+        pip install build twine
+        pip install .
     - name: Build and publish
       env:
-        FLIT_USERNAME: '__token__'
-        FLIT_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        PYPI_USERNAME: '__token__'
+        PYPI_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
-        flit publish
+        python -m build
+        python -m twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # PyCharm
 .idea/
+
+# scm version
+ceresfit/_version.py

--- a/ceresfit/__init__.py
+++ b/ceresfit/__init__.py
@@ -1,9 +1,9 @@
 """Linear regression of data sets with correlated and uncorrelated uncertainties."""
 
+from _.version import __version__
 from .ceresfit_linreg import LinReg
 
 # Package information
-__version__ = "0.2.1"
 __all__ = ["LinReg"]
 
 __title__ = "ceresfit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["flit_scm"]
+build-backend = "flit_scm:buildapi"
 
 [project]
 authors = [{name = "Reto Trappitsch", email = "reto@galactic-forensics.space"}]
@@ -25,7 +25,7 @@ readme = "README.md"
 requires-python=">=3.8"
 
 [project.urls]
-Home = "https://github.com/galactic-forensics/CEREsFit"
+Source = "https://github.com/galactic-forensics/CEREsFit"
 
 [project.optional-dependencies]
 dev = [
@@ -46,9 +46,12 @@ test = [
 ]
 
 [tool.flit.sdist]
-exclude = ["examples/"]
+exclude = ["examples/", ".gitignore"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "--cov=ceresfit --cov-report=xml"
 testpaths = "tests"
+
+[tool.setuptools_scm]
+write_to = "ceresfit/_version.py"


### PR DESCRIPTION
- Update automatic versioning using GitHub tags
- When a release is created, the tag version of that release is used as the version number of the package
- Building a package is now done with `build` and upload with `twine`
